### PR TITLE
Add option to scroll inside an element on the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ by default. If you want more control over the scrolling however, you can create 
 * offset: The amount of space in pixels between the element to scroll to and the top of the viewport that is to remain after scrolling. Defaults to 12.
 * speed: The speed with which the scrolling is to take place. Experiment to find the value that works for you. 100 is the default.
 * easing: The easing function to use. Check out the [easing functions](https://package.elm-lang.org/packages/elm-community/easing-functions/latest/) package for more information. `Ease.outQuint` is the default.
+* container: Which element to scroll inside of. Defaults to the document body, but can be configured with `containerElement`.
 
 You can then pass this config record to the `scrollToWithOptions` function.
 

--- a/example/src/ExampleInner.elm
+++ b/example/src/ExampleInner.elm
@@ -6,7 +6,7 @@ import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import SmoothScroll exposing (scrollToWithOptions, defaultConfig, containerElement)
+import SmoothScroll exposing (containerElement, defaultConfig, scrollToWithOptions)
 import Task exposing (Task)
 
 
@@ -49,34 +49,46 @@ update msg model =
 
 view : Model -> Document Msg
 view model =
-    { title = "Foo"
+    { title = "Scroll Inside Elements"
     , body =
-        [ div [ style "position" "fixed", style "top" "0", style "height" "40px", style "left" "0", style "right" "0", style "display" "flex", style "justify-content" "space-around" ]
+        [ div topBarStyles
             [ div []
                 [ button [ onClick (SmoothScroll "left-half" "anchor-left-100") ] [ text "100" ]
-                , button [ onClick (SmoothScroll "left-half" "anchor-left-25")] [ text "25" ]
-                , button [ onClick (SmoothScroll "left-half" "anchor-left-1")] [ text "1" ]
+                , button [ onClick (SmoothScroll "left-half" "anchor-left-25") ] [ text "25" ]
+                , button [ onClick (SmoothScroll "left-half" "anchor-left-1") ] [ text "1" ]
                 ]
             , div []
                 [ button [ onClick (SmoothScroll "right-half" "anchor-right-100") ] [ text "100" ]
-                , button [ onClick (SmoothScroll "right-half" "anchor-right-25")] [ text "25" ]
-                , button [ onClick (SmoothScroll "right-half" "anchor-right-1")] [ text "1" ]
+                , button [ onClick (SmoothScroll "right-half" "anchor-right-25") ] [ text "25" ]
+                , button [ onClick (SmoothScroll "right-half" "anchor-right-1") ] [ text "1" ]
                 ]
             ]
-        , div [ style "font-size" "18px", style "font-family" "sans-serif",  style "position" "fixed", style "top" "40px", style "bottom" "0", style "left" "0", style "right" "0", style "display" "flex" ]
-            [ div [  id "left-half", style "flex-grow" "1", style "overflow-y" "scroll", style "border" "1px solid #ccc", style "background" "cornflowerblue" ]
-                [ ul [  ]
-                    (List.range 1 100
-                        |> List.map (\num -> li [ String.fromInt num |> String.append "anchor-left-" |> id ] [ text <| String.fromInt num ])
-                    )
+        , div rowStyles
+            [ div ([ id "left-half", style "background" "cornflowerblue" ] ++ columnStyles)
+                [ ul []
+                    (List.range 1 100 |> List.map (anchorView "left"))
                 ]
-            , div [  id "right-half", style "flex-grow" "1", style "overflow-y" "scroll", style "border" "1px solid #ccc", style "background" "wheat" ]
-                [ ul [  ]
-                    (List.range 1 100
-                        |> List.map (\num -> li [ String.fromInt num |> String.append "anchor-right-" |> id ] [ text <| String.fromInt num ])
-                    )
+            , div ([ id "right-half", style "background" "wheat" ] ++ columnStyles)
+                [ ul []
+                    (List.range 1 100 |> List.map (anchorView "right"))
                 ]
             ]
         ]
-
     }
+
+
+anchorView side num =
+    li [ String.fromInt num |> String.append ("anchor-" ++ side ++ "-") |> id ]
+        [ text <| String.fromInt num ]
+
+
+topBarStyles =
+    [ style "position" "fixed", style "top" "0", style "height" "40px", style "left" "0", style "right" "0", style "display" "flex", style "justify-content" "space-around" ]
+
+
+rowStyles =
+    [ style "font-size" "18px", style "font-family" "sans-serif", style "position" "fixed", style "top" "40px", style "bottom" "0", style "left" "0", style "right" "0", style "display" "flex" ]
+
+
+columnStyles =
+    [ style "flex-grow" "1", style "overflow-y" "scroll", style "border" "1px solid #ccc" ]

--- a/example/src/ExampleInner.elm
+++ b/example/src/ExampleInner.elm
@@ -1,0 +1,82 @@
+module ExampleInner exposing (main)
+
+import Browser exposing (Document)
+import Browser.Dom as Dom
+import Dict exposing (Dict)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import SmoothScroll exposing (scrollToWithOptions, defaultConfig, containerElement)
+import Task exposing (Task)
+
+
+main =
+    Browser.document
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( { foo = "bar" }, Cmd.none )
+
+
+type alias Model =
+    { foo : String }
+
+
+type Msg
+    = NoOp
+    | SmoothScroll String String
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
+
+        SmoothScroll containerId targetId ->
+            ( model
+            , targetId
+                |> scrollToWithOptions { defaultConfig | speed = 15, container = containerElement containerId }
+                |> Task.attempt (always NoOp)
+            )
+
+
+view : Model -> Document Msg
+view model =
+    { title = "Foo"
+    , body =
+        [ div [ style "position" "fixed", style "top" "0", style "height" "40px", style "left" "0", style "right" "0", style "display" "flex", style "justify-content" "space-around" ]
+            [ div []
+                [ button [ onClick (SmoothScroll "left-half" "anchor-left-100") ] [ text "100" ]
+                , button [ onClick (SmoothScroll "left-half" "anchor-left-25")] [ text "25" ]
+                , button [ onClick (SmoothScroll "left-half" "anchor-left-1")] [ text "1" ]
+                ]
+            , div []
+                [ button [ onClick (SmoothScroll "right-half" "anchor-right-100") ] [ text "100" ]
+                , button [ onClick (SmoothScroll "right-half" "anchor-right-25")] [ text "25" ]
+                , button [ onClick (SmoothScroll "right-half" "anchor-right-1")] [ text "1" ]
+                ]
+            ]
+        , div [ style "font-size" "18px", style "font-family" "sans-serif",  style "position" "fixed", style "top" "40px", style "bottom" "0", style "left" "0", style "right" "0", style "display" "flex" ]
+            [ div [  id "left-half", style "flex-grow" "1", style "overflow-y" "scroll", style "border" "1px solid #ccc", style "background" "cornflowerblue" ]
+                [ ul [  ]
+                    (List.range 1 100
+                        |> List.map (\num -> li [ String.fromInt num |> String.append "anchor-left-" |> id ] [ text <| String.fromInt num ])
+                    )
+                ]
+            , div [  id "right-half", style "flex-grow" "1", style "overflow-y" "scroll", style "border" "1px solid #ccc", style "background" "wheat" ]
+                [ ul [  ]
+                    (List.range 1 100
+                        |> List.map (\num -> li [ String.fromInt num |> String.append "anchor-right-" |> id ] [ text <| String.fromInt num ])
+                    )
+                ]
+            ]
+        ]
+
+    }

--- a/example/src/elm.json
+++ b/example/src/elm.json
@@ -1,0 +1,26 @@
+{
+    "type": "application",
+    "source-directories": [
+        ".",
+        "../../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm-community/easing-functions": "2.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/src/SmoothScroll.elm
+++ b/src/SmoothScroll.elm
@@ -45,6 +45,8 @@ type alias Config =
     }
 
 
+{-| An internal type for configuring which element to scroll within.
+-}
 type Container
     = DocumentBody
     | InnerNode String

--- a/src/SmoothScroll.elm
+++ b/src/SmoothScroll.elm
@@ -79,7 +79,7 @@ defaultConfig =
 
     import SmoothScroll exposing (scrollToWithOptions, defaultConfig, containerElement)
 
-    scrollToWithOptions { defaultConfig | containerElement = "article-list" } "article-42"
+    scrollToWithOptions { defaultConfig | container = containerElement "article-list" } "article-42"
 
 -}
 containerElement : String -> Container

--- a/src/SmoothScroll.elm
+++ b/src/SmoothScroll.elm
@@ -13,6 +13,7 @@ module SmoothScroll exposing
 
 @docs Config
 @docs defaultConfig
+@docs containerElement
 
 
 # Scrolling
@@ -28,11 +29,12 @@ import Internal.SmoothScroll exposing (animationSteps)
 import Task exposing (Task)
 
 
-{-| Configuration options for smooth scrolling. Has three options:
+{-| Configuration options for smooth scrolling. Has four options:
 
   - offset: The amount of space in pixels between the element to scroll to and the top of the viewport that is to remain after scrolling
   - speed: The higher this number, the faster the scrolling!
   - easing: The easing function to use. Check out the [easing functions](https://package.elm-lang.org/packages/elm-community/easing-functions/latest/) package for more information.
+  - container: Which element to scroll inside of. Defaults to the document body, but can be configured with [`containerElement`](#containerElement)
 
 -}
 type alias Config =
@@ -48,7 +50,10 @@ type Container
     | InnerNode String
 
 
-    import SmoothScroll
+{-| The default configuration which can be modified
+
+    import Ease
+    import SmoothScroll exposing (defaultConfig)
 
     defaultConfig : Config
     defaultConfig =
@@ -82,7 +87,7 @@ containerElement elementId =
 
 {-| Scroll to the element with the given id, using the default configuration
 
-    import SmoothScroll
+    import SmoothScroll exposing (scrollTo)
 
     scrollTo "article"
 
@@ -94,7 +99,7 @@ scrollTo =
 
 {-| Scroll to the element with the given id, using a custom configuration
 
-    import SmoothScroll exposing (defaultConfig)
+    import SmoothScroll exposing (defaultConfig, scrollToWithOptions)
 
     scrollToWithOptions { defaultConfig | offset = 60 } "article"
 


### PR DESCRIPTION
I forked this for my own project but I think scrolling with individual elements has good general use cases (chat boxes, long side navigation, etc.) with no major version changes

- Adds option to scroll with a DOM element instead of the document body
- Adds an example .elm file for this
- Cleans up documentation a bit

Scrolling within a DOM element requires a few more variables to keep track of so it's a few lines longer but it's been a big help for me. Thanks for the great package.

Cheers